### PR TITLE
ci: clear ruff backlog so the lint gate is trustworthy

### DIFF
--- a/marlinspike/emit/navigator.py
+++ b/marlinspike/emit/navigator.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from typing import Any
 
 # ── Constants ────────────────────────────────────────────────────────────────
 

--- a/marlinspike/emit/sigma.py
+++ b/marlinspike/emit/sigma.py
@@ -96,7 +96,9 @@ def _now_iso_date() -> str:
 
 def _stable_uuid(category: str, key: str) -> str:
     """Sigma ``id`` field — UUID-shape stable hash."""
-    h = hashlib.sha1(f"marlinspike|{category}|{key}".encode()).hexdigest()
+    h = hashlib.sha1(
+        f"marlinspike|{category}|{key}".encode(), usedforsecurity=False
+    ).hexdigest()
     # Format as a UUID for Sigma compatibility
     return f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
 

--- a/marlinspike/recovery.py
+++ b/marlinspike/recovery.py
@@ -36,7 +36,7 @@ import time
 from datetime import datetime, timezone
 
 from marlinspike import config, run_store
-from marlinspike.models import ScanHistory, db
+from marlinspike.models import ScanHistory
 
 log = logging.getLogger("marlinspike.recovery")
 

--- a/marlinspike/setup_wizard.py
+++ b/marlinspike/setup_wizard.py
@@ -116,11 +116,11 @@ def _print_summary(env: dict[str, str], env_path: Path):
     print("=" * 60)
     print(f"  .env written: {env_path.resolve()} (mode 0600)")
     print(f"  DATABASE_URL: {_redact(env.get('DATABASE_URL', ''))}")
-    print(f"  SECRET_KEY:   <generated, 64 hex chars>")
+    print("  SECRET_KEY:   <generated, 64 hex chars>")
     if env.get("ADMIN_PASSWORD"):
         print()
         print("  ADMIN BOOTSTRAP CREDENTIAL")
-        print(f"  username: admin")
+        print("  username: admin")
         print(f"  password: {env['ADMIN_PASSWORD']}")
         print("  Change this immediately after first login.")
     print()

--- a/marlinspike/taxonomy.py
+++ b/marlinspike/taxonomy.py
@@ -28,11 +28,9 @@ always an association between an existing entity and an IOC, not a new node.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, asdict
-from enum import Enum
-from typing import Optional
 import json
-
+from dataclasses import dataclass
+from enum import Enum
 
 # ---------------------------------------------------------------------------
 # Entity types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,10 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*" = ["S101", "S105", "S106", "S311"]
-"scripts/**/*" = ["S101", "S105", "S106", "S311"]
+# S108: tests use synthetic /tmp placeholder paths as opaque identifiers
+# (never written) — same false-positive class as the S105/6 ignores above.
+"tests/**/*" = ["S101", "S105", "S106", "S108", "S311"]
+"scripts/**/*" = ["S101", "S105", "S106", "S108", "S311"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tests/test_navigator_emit.py
+++ b/tests/test_navigator_emit.py
@@ -6,8 +6,6 @@ import json
 import os
 import sys
 
-import pytest
-
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test-navigator")
 
@@ -16,7 +14,6 @@ if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
 from marlinspike.emit import navigator  # noqa: E402
-
 
 SAMPLE_REPORT = {
     "capture_info": {"capture_source": "test-capture-001"},

--- a/tests/test_ocsf_emit.py
+++ b/tests/test_ocsf_emit.py
@@ -6,8 +6,6 @@ import json
 import os
 import sys
 
-import pytest
-
 # Set DATABASE_URL BEFORE importing marlinspike (config reads at import time).
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test-ocsf")
@@ -17,7 +15,6 @@ if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
 from marlinspike.emit import ocsf  # noqa: E402
-
 
 # ── Sample report fixture ────────────────────────────────────────────────────
 

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -6,7 +6,6 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 import time
 from datetime import datetime, timedelta, timezone
 

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import tempfile
-from datetime import datetime, timedelta, timezone
 
 # Set DATABASE_URL BEFORE importing marlinspike — config reads at import time.
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")

--- a/tests/test_security_v352.py
+++ b/tests/test_security_v352.py
@@ -13,7 +13,6 @@ Covers:
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 
@@ -226,7 +225,7 @@ def test_setup_wizard_auto_writes_env(tmp_path, monkeypatch):
 
 
 def test_setup_wizard_secret_key_strength(tmp_path):
-    from marlinspike.setup_wizard import run, _gen_secret_hex
+    from marlinspike.setup_wizard import _gen_secret_hex
     # The auto-generated key should be 64 hex chars (256 bits)
     assert len(_gen_secret_hex(32)) == 64
     # And different on every call

--- a/tests/test_sigma_emit.py
+++ b/tests/test_sigma_emit.py
@@ -6,8 +6,6 @@ import json
 import os
 import sys
 
-import pytest
-
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test-sigma")
 
@@ -16,7 +14,6 @@ if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
 from marlinspike.emit import sigma  # noqa: E402
-
 
 SAMPLE_REPORT = {
     "capture_info": {"capture_source": "test-001"},

--- a/tests/test_stix_emit.py
+++ b/tests/test_stix_emit.py
@@ -6,8 +6,6 @@ import json
 import os
 import sys
 
-import pytest
-
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("SECRET_KEY", "test-stix")
 
@@ -16,7 +14,6 @@ if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
 from marlinspike.emit import stix  # noqa: E402
-
 
 SAMPLE_REPORT = {
     "timestamp_start": "2026-05-09T15:10:00Z",

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -5,22 +5,19 @@ chip helpers, severity chip mapping, and JSON export round-trip.
 """
 
 import json
-import pytest
 
 from marlinspike.taxonomy import (
+    ENTITY_VISUALS,
     EntityType,
     EntityVisual,
     RelationshipType,
-    ENTITY_VISUALS,
-    SEVERITY_CHIP,
     chip_for,
     chip_for_full,
-    severity_chip_class,
     label,
+    severity_chip_class,
     taxonomy_export,
     taxonomy_export_json,
 )
-
 
 # ---------------------------------------------------------------------------
 # 1. Every EntityType has a visual entry


### PR DESCRIPTION
## Make the CI lint gate trustworthy

The CI `ruff` step (fatal on a fixed list of modules + tests) has been **red on `main`** with **42 pre-existing errors**, unrelated to any feature work. A required check that nobody can pass trains everyone to ignore CI — and it currently masks real signal on feature PRs (e.g. #5, whose tests pass but whose run shows red purely from this backlog).

This PR clears it. **No functional change; 336 tests still pass.**

### Changes
- **26 auto-fixed** (`ruff --fix`): unused imports (`F401`), import order (`I001`), empty f-strings (`F541`) across `emit/`, `setup_wizard`, `recovery`, `taxonomy` and their tests.
- **`emit/sigma.py` `S324`**: the `sha1` call builds a stable UUID-shaped Sigma `id`, not a security digest → `usedforsecurity=False`. Hash output is **identical**, so existing Sigma rule IDs are stable — no consumer or test breakage.
- **`pyproject.toml` `S108`**: ignored for `tests/**` + `scripts/**`. The 15 hits are synthetic `/tmp/x.pcap`-style placeholder paths used as opaque identifiers (never written) — same false-positive class as the existing `S105`/`S106` test ignores, and the config comment already acknowledges that rationale.

### Verification
- `ruff check` on the exact CI fatal-list → **All checks passed**
- Full suite → **336 passed**

Merge this first; feature PR #5 then goes green on rebase.
